### PR TITLE
Changed name of default route from "API Default" to "DefaultApi" which is used by ASP.NET Web API RTM.

### DIFF
--- a/Hyprlinkr.UnitTest/DefaultRouteDispatcherTests.cs
+++ b/Hyprlinkr.UnitTest/DefaultRouteDispatcherTests.cs
@@ -38,7 +38,7 @@ namespace Ploeh.Hyprlinkr.UnitTest
         public void DefaultRouteNameIsCorrect(
             [Modest]DefaultRouteDispatcher sut)
         {
-            Assert.Equal("API Default", sut.RouteName);
+            Assert.Equal("DefaultApi", sut.RouteName);
         }
 
         [Theory, AutoHypData]
@@ -48,7 +48,7 @@ namespace Ploeh.Hyprlinkr.UnitTest
             IDictionary<string, object> routeValues)
         {
             var actual = sut.Dispatch(method, routeValues);
-            Assert.Equal("API Default", actual.RouteName);
+            Assert.Equal("DefaultApi", actual.RouteName);
         }
 
         [Theory, AutoHypData]

--- a/Hyprlinkr.UnitTest/RouteConfiguration.cs
+++ b/Hyprlinkr.UnitTest/RouteConfiguration.cs
@@ -18,7 +18,7 @@ namespace Ploeh.Hyprlinkr.UnitTest
         {
             request.RequestUri = new Uri(request.RequestUri, "api/qux");
             request.AddRoute(
-                name: "API Default",
+                name: "DefaultApi",
                 routeTemplate: "api/{controller}/{id}",
                 defaults: new { id = RouteParameter.Optional });
         }

--- a/Hyprlinkr.UnitTest/RouteLinkerTests.cs
+++ b/Hyprlinkr.UnitTest/RouteLinkerTests.cs
@@ -193,7 +193,7 @@ namespace Ploeh.Hyprlinkr.UnitTest
         {
             request.RequestUri = new Uri(request.RequestUri, "api/foo/" + currentId);
             request.AddRoute(
-                name: "API Default",
+                name: "DefaultApi",
                 routeTemplate: "api/{controller}/{id}",
                 defaults: new
                 {

--- a/Hyprlinkr/DefaultRouteDispatcher.cs
+++ b/Hyprlinkr/DefaultRouteDispatcher.cs
@@ -19,7 +19,7 @@ namespace Ploeh.Hyprlinkr
         /// Initializes a new instance of the <see cref="DefaultRouteDispatcher" /> class.
         /// </summary>
         public DefaultRouteDispatcher()
-            : this("API Default")
+            : this("DefaultApi")
         {
         }
 


### PR DESCRIPTION
Fixed #6
