### PR TITLE
Fixed bug in ResourceLinkVerifier.Verify that led to a wrong result when...

### DIFF
--- a/Hyprlinkr.UnitTest/Hyprlinkr.UnitTest.csproj
+++ b/Hyprlinkr.UnitTest/Hyprlinkr.UnitTest.csproj
@@ -121,6 +121,10 @@
       <DependentUpon>Reflect.Overloads.tt</DependentUpon>
     </Compile>
     <Compile Include="RedirectRouteHandler.cs" />
+    <Compile Include="ReflectionExtensionsTest.cs" />
+    <Compile Include="ReflectionHierarchy\Base.cs" />
+    <Compile Include="ReflectionHierarchy\Derived.cs" />
+    <Compile Include="ReflectionHierarchy\DerivedFromDerived.cs" />
     <Compile Include="ResourceLinkVerifierTests.cs" />
     <Compile Include="RoupleTests.cs" />
     <Compile Include="RouteConfiguration.cs" />

--- a/Hyprlinkr.UnitTest/ReflectionExtensionsTest.cs
+++ b/Hyprlinkr.UnitTest/ReflectionExtensionsTest.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Ploeh.Hyprlinkr.UnitTest.ReflectionHierarchy;
+using Xunit;
+using Xunit.Extensions;
+
+namespace Ploeh.Hyprlinkr.UnitTest
+{
+    public class ReflectionExtensionsTest
+    {
+        [Theory]
+        [AutoHypData]
+        public void ComparingTwoMethodInfoObjects_ReturnsFalse_WhenBothAreDifferent(MethodInfo left, MethodInfo right)
+        {
+            Assert.True(left.RefersToTheSameMethodAs(right));
+        }
+
+        [Fact]
+        public void ComparingTwoMethodInfoObjects_ReturnsFalse_WhenLeftIsAnOverloadOfRight()
+        {
+            var left = typeof(Base).GetMethod("Overloaded", new Type[0]);
+            var right = typeof(Base).GetMethod("Overloaded", new[] { typeof(int) });
+            Assert.False(left.RefersToTheSameMethodAs(right));
+        }
+
+        [Fact]
+        public void ComparingTwoMethodInfoObjects_ReturnsFalse_WhenLeftIsFromABaseBaseClassOfRightAndTheMethodHasBeenOverridenOnlyInTheBaseClassOfRight()
+        {
+            var left = typeof(Base).GetMethod("Foo");
+            var right = typeof(DerivedFromDerived).GetMethod("Foo");
+            Assert.False(left.RefersToTheSameMethodAs(right));
+        }
+
+        [Fact]
+        public void ComparingTwoMethodInfoObjects_ReturnsFalse_WhenLeftIsFromABaseClassOfRightAndTheMethodHasBeenOverridenInRight()
+        {
+            var left = typeof(Base).GetMethod("Foo");
+            var right = typeof(Derived).GetMethod("Foo");
+            Assert.False(left.RefersToTheSameMethodAs(right));
+        }
+
+        [Fact]
+        public void ComparingTwoMethodInfoObjects_ReturnsFalse_WhenRightIsFromABaseBaseClassOfLeftAndTheMethodHasBeenOverridenOnlyInTheBaseClassOfLeft()
+        {
+            var left = typeof(DerivedFromDerived).GetMethod("Foo");
+            var right = typeof(Base).GetMethod("Foo");
+            Assert.False(left.RefersToTheSameMethodAs(right));
+        }
+
+        [Fact]
+        public void ComparingTwoMethodInfoObjects_ReturnsFalse_WhenRightIsFromABaseClassOfLeftAndTheMethodHasBeenOverridenInLeft()
+        {
+            var left = typeof(Derived).GetMethod("Foo");
+            var right = typeof(Base).GetMethod("Foo");
+            Assert.False(left.RefersToTheSameMethodAs(right));
+        }
+
+        [Theory]
+        [AutoHypData]
+        public void ComparingTwoMethodInfoObjects_ReturnsTrue_WhenBothAreFromTheSameTypeAndForTheSameMethod(Type type)
+        {
+            var methods = type.GetMethods();
+            var left = methods.First();
+            var right = methods.First();
+            Assert.True(left.RefersToTheSameMethodAs(right));
+        }
+
+        [Theory]
+        [AutoHypData]
+        public void ComparingTwoMethodInfoObjects_ReturnsTrue_WhenBothAreTheSameInstance(MethodInfo method)
+        {
+            Assert.True(method.RefersToTheSameMethodAs(method));
+        }
+
+        [Fact]
+        public void ComparingTwoMethodInfoObjects_ReturnsTrue_WhenLeftIsFromABaseBaseClassOfRightAndTheMethodHasNotBeenOverridenInRightOrItsDirectBaseClass()
+        {
+            var left = typeof(Base).GetMethod("Bar");
+            var right = typeof(DerivedFromDerived).GetMethod("Bar");
+            Assert.True(left.RefersToTheSameMethodAs(right));
+        }
+
+        [Fact]
+        public void ComparingTwoMethodInfoObjects_ReturnsTrue_WhenLeftIsFromABaseClassOfRightAndTheMethodHasNotBeenOverridenInRight()
+        {
+            var left = typeof(Base).GetMethod("Bar");
+            var right = typeof(Derived).GetMethod("Bar");
+            Assert.True(left.RefersToTheSameMethodAs(right));
+        }
+
+        [Fact]
+        public void ComparingTwoMethodInfoObjects_ReturnsTrue_WhenLeftIsFromABaseClassOfRightAndTheMethodHasntBeenOverridenInRight()
+        {
+            var left = typeof(Base).GetMethod("Bar");
+            var right = typeof(Derived).GetMethod("Bar");
+            Assert.True(left.RefersToTheSameMethodAs(right));
+        }
+
+        [Fact]
+        public void ComparingTwoMethodInfoObjects_ReturnsTrue_WhenRightIsFromABaseBaseClassOfLeftAndTheMethodHasNotBeenOverridenInLeftOrItsDirectBaseClass()
+        {
+            var left = typeof(DerivedFromDerived).GetMethod("Bar");
+            var right = typeof(Base).GetMethod("Bar");
+            Assert.True(left.RefersToTheSameMethodAs(right));
+        }
+
+        [Fact]
+        public void ComparingTwoMethodInfoObjects_ReturnsTrue_WhenRightIsFromABaseClassOfLeftAndTheMethodHasNotBeenOverridenInLeft()
+        {
+            var left = typeof(Derived).GetMethod("Bar");
+            var right = typeof(Base).GetMethod("Bar");
+            Assert.True(left.RefersToTheSameMethodAs(right));
+        }
+
+        [Fact]
+        public void ComparingTwoMethodInfoObjects_ReturnsTrue_WhenRightIsFromABaseClassOfLeftAndTheMethodHasntBeenOverridenInLeft()
+        {
+            var left = typeof(Derived).GetMethod("Bar");
+            var right = typeof(Base).GetMethod("Bar");
+            Assert.True(left.RefersToTheSameMethodAs(right));
+        }
+
+        [Theory]
+        [AutoHypData]
+        public void ComparingTwoMethodInfoObjects_ThrowsArgumentNullException_WhenLeftIsNull(MethodInfo right)
+        {
+            MethodInfo left = null;
+            Assert.Throws<ArgumentNullException>(() => left.RefersToTheSameMethodAs(right));
+        }
+
+        [Theory]
+        [AutoHypData]
+        public void ComparingTwoMethodInfoObjects_ThrowsArgumentNullException_WhenRightIsNull(MethodInfo left)
+        {
+            MethodInfo right = null;
+            Assert.Throws<ArgumentNullException>(() => left.RefersToTheSameMethodAs(right));
+        }
+    }
+}

--- a/Hyprlinkr.UnitTest/ReflectionHierarchy/Base.cs
+++ b/Hyprlinkr.UnitTest/ReflectionHierarchy/Base.cs
@@ -1,0 +1,21 @@
+﻿namespace Ploeh.Hyprlinkr.UnitTest.ReflectionHierarchy
+{
+    public class Base
+    {
+        public virtual void Foo()
+        {
+        }
+
+        public virtual void Bar()
+        {
+        }
+
+        public virtual void Overloaded()
+        {
+        }
+
+        public virtual void Overloaded(int p)
+        {
+        }
+    }
+}

--- a/Hyprlinkr.UnitTest/ReflectionHierarchy/Derived.cs
+++ b/Hyprlinkr.UnitTest/ReflectionHierarchy/Derived.cs
@@ -1,0 +1,9 @@
+﻿namespace Ploeh.Hyprlinkr.UnitTest.ReflectionHierarchy
+{
+    public class Derived : Base
+    {
+        public override void Foo()
+        {
+        }
+    }
+}

--- a/Hyprlinkr.UnitTest/ReflectionHierarchy/DerivedFromDerived.cs
+++ b/Hyprlinkr.UnitTest/ReflectionHierarchy/DerivedFromDerived.cs
@@ -1,0 +1,6 @@
+﻿namespace Ploeh.Hyprlinkr.UnitTest.ReflectionHierarchy
+{
+    public class DerivedFromDerived : Derived
+    {
+    }
+}

--- a/Hyprlinkr.UnitTest/ResourceLinkVerifierTests.cs
+++ b/Hyprlinkr.UnitTest/ResourceLinkVerifierTests.cs
@@ -240,17 +240,8 @@ namespace Ploeh.Hyprlinkr.UnitTest
             Assert.False(actual);
         }
 
-        [Theory, AutoHypData]
-        public void VerifyReturnsTrueWhenActionContextMatchesExpression(ResourceLinkVerifier sut, int id)
-        {
-            var actionContext = GetActionContext<FooController>(x => x.GetById(id));
-
-            var actual = sut.Verify<FooController>(actionContext, x => x.GetById(Arg.OfType<int>()));
-
-            Assert.True(actual);
-        }
-
-        [Theory, AutoHypData]
+        [Theory]
+        [AutoHypData]
         public void VerifyReturnsFalseWhenActionContextIsForCorrectControllerButWrongAction(ResourceLinkVerifier sut, int id)
         {
             var actionContext = GetActionContext<FooController>(x => x.GetById(id));
@@ -260,7 +251,8 @@ namespace Ploeh.Hyprlinkr.UnitTest
             Assert.False(actual);
         }
 
-        [Theory, AutoHypData]
+        [Theory]
+        [AutoHypData]
         public void VerifyReturnsFalseWhenActionContextIsForWrongController(ResourceLinkVerifier sut)
         {
             var actionContext = GetActionContext<FooController>(x => x.GetDefault());
@@ -268,6 +260,28 @@ namespace Ploeh.Hyprlinkr.UnitTest
             var actual = sut.Verify<BarController>(actionContext, x => x.GetDefault());
 
             Assert.False(actual);
+        }
+
+        [Theory]
+        [AutoHypData]
+        public void VerifyReturnsTrueWhenActionContextIsForMethodDeclaredOnControllerBaseType(ResourceLinkVerifier sut)
+        {
+            var actionContext = GetActionContext<DerivedController>(x => x.BaseMethod());
+
+            var actual = sut.Verify<DerivedController>(actionContext, x => x.BaseMethod());
+
+            Assert.True(actual);
+        }
+
+        [Theory]
+        [AutoHypData]
+        public void VerifyReturnsTrueWhenActionContextMatchesExpression(ResourceLinkVerifier sut, int id)
+        {
+            var actionContext = GetActionContext<FooController>(x => x.GetById(id));
+
+            var actual = sut.Verify<FooController>(actionContext, x => x.GetById(Arg.OfType<int>()));
+
+            Assert.True(actual);
         }
 
         private static HttpActionContextResemblance GetActionContext<TController>(

--- a/Hyprlinkr/Hyprlinkr.csproj
+++ b/Hyprlinkr/Hyprlinkr.csproj
@@ -84,6 +84,7 @@
     <Compile Include="IRouteDispatcher.cs" />
     <Compile Include="IResourceLinker.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ReflectionExtensions.cs" />
     <Compile Include="ResourceLinkVerifier.cs" />
     <Compile Include="Rouple.cs" />
     <Compile Include="RouteLinker.cs" />

--- a/Hyprlinkr/ReflectionExtensions.cs
+++ b/Hyprlinkr/ReflectionExtensions.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Reflection;
+
+namespace Ploeh.Hyprlinkr
+{
+    /// <summary>A class with some extension methods with regards to reflection.</summary>
+    public static class ReflectionExtensions
+    {
+        /// <summary>Checks whether <paramref name="left"/> refers to the same method as <paramref name="right"/>.</summary>
+        /// <param name="left">The left operand.</param>
+        /// <param name="right">The right operand.</param>
+        /// <returns><c>true</c> if <paramref name="left"/> refers to the same method as <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        /// <remarks>
+        ///     <para>
+        /// Two <see cref="MethodInfo"/> instances can be un-equal although they refer to the same physical method. This happens when <c>Base</c> has a virtual method
+        ///         <c>Foo</c> and <c>Derived</c>derives from <c>Base</c> but doesn't override <c>Foo</c>.
+        ///     </para>
+        ///     <para>
+        /// Example:
+        ///         <code><![CDATA[
+        /// var baseMethod = typeof(Base).GetMethod("Foo");
+        /// var derivedMethod = typeof(Derived).GetMethod("Foo");
+        /// Assert.False(baseMethod.Equals(derivedMethod));]]></code>
+        ///     </para>
+        ///     <para>
+        /// The difference comes from the fact that for both <c>baseMethod</c> and <c>derivedMethod</c> the property <see cref="MemberInfo.DeclaringType"/> is <c>Base</c>,
+        /// but the <see cref="MemberInfo.ReflectedType"/> is the class specified in the <see langword="typeof"/>.
+        ///     </para>
+        ///     <para>Especially when mixing reflection and expressions, this becomes a problem.</para>
+        ///     <para>The following assert will succeed in both cases:</para>
+        ///     <para>
+        ///         <code><![CDATA[
+        /// void Test<T>(Expression<Action<T>> expression)
+        /// {
+        ///     Assert.Equal(typeof(Base), ((MethodCallExpression)expression.Body).Method.ReflectedType);
+        /// }
+        /// 
+        /// Test<Base>(x => x.Foo());
+        /// Test<Derived>(x => x.Foo());
+        /// ]]></code>
+        ///     </para>
+        ///     <para>
+        /// When trying to compare the <see cref="MethodInfo"/> instance from the expression with that created by reflection, the result will be <c>false</c> as soon as
+        /// the reflection instance has been created from a derived type
+        ///     </para>
+        /// </remarks>
+        public static bool RefersToTheSameMethodAs(this MethodInfo left, MethodInfo right)
+        {
+            if (left == null)
+                throw new ArgumentNullException("left");
+            if (right == null)
+                throw new ArgumentNullException("right");
+
+            return left.MethodHandle.Equals(right.MethodHandle);
+        }
+    }
+}

--- a/Hyprlinkr/ResourceLinkVerifier.cs
+++ b/Hyprlinkr/ResourceLinkVerifier.cs
@@ -128,7 +128,9 @@ namespace Ploeh.Hyprlinkr
             if (expectedAction == null)
                 throw new ArgumentNullException("expectedAction");
 
-            if (actionContext.ControllerContext.ControllerDescriptor.ControllerType != typeof(TController))
+            var expectedActionMethod = expectedAction.GetMethodInfo();
+
+            if (actionContext.ControllerContext.ControllerDescriptor.ControllerType != expectedActionMethod.DeclaringType)
                 return false;
 
             MethodInfo actualActionMethod;
@@ -138,9 +140,7 @@ namespace Ploeh.Hyprlinkr
             else
                 actualActionMethod = actionDescriptor.MethodInfo;
 
-            var expectedActionMethod = expectedAction.GetMethodInfo();
-
-            return actualActionMethod == expectedActionMethod;
+            return actualActionMethod.RefersToTheSameMethodAs(expectedActionMethod);
         }
 
         /// <summary>


### PR DESCRIPTION
... a controller has been used that derived from another class and the action method has been declared in the base class and not been overriden in the derived controller.

Please see comment on https://github.com/dhilgarth/Hyprlinkr/blob/bug/ResourceLinkVerifier/DerivedController/Hyprlinkr/ReflectionExtensions.cs if you are interested in the details.

BTW: I would appreciate some suggestions on how to improve the names of the tests in ReflectionExtensionsTest.
