### PR TITLE
Fixed bug in unit test and in ResourceLinkVerifier with regards to derived controllers

### DIFF
--- a/Hyprlinkr.UnitTest/TestExtensions.cs
+++ b/Hyprlinkr.UnitTest/TestExtensions.cs
@@ -11,14 +11,14 @@ namespace Ploeh.Hyprlinkr.UnitTest
         {
             var bodyCallExpression = expression.GetBodyMethodCallExpression();
             var methodInfo = bodyCallExpression.Method;
-            var controllerDescriptor = new HttpControllerDescriptor { ControllerType = methodInfo.DeclaringType };
+            var controllerDescriptor = new HttpControllerDescriptor { ControllerType = typeof(TController) };
             var actionContext =
                 new HttpActionContext(
                     new HttpControllerContext { ControllerDescriptor = controllerDescriptor }, 
                     new ReflectedHttpActionDescriptor(controllerDescriptor, methodInfo));
 
             var parameters = bodyCallExpression.Method.GetParameters().ToDictionary(
-                p => p.Name, p => bodyCallExpression.GetParameterValue(p));
+                p => p.Name, bodyCallExpression.GetParameterValue);
 
             foreach (var kvp in parameters)
                 actionContext.ActionArguments.Add(kvp.Key, kvp.Value);

--- a/Hyprlinkr/ResourceLinkVerifier.cs
+++ b/Hyprlinkr/ResourceLinkVerifier.cs
@@ -130,9 +130,6 @@ namespace Ploeh.Hyprlinkr
 
             var expectedActionMethod = expectedAction.GetMethodInfo();
 
-            if (actionContext.ControllerContext.ControllerDescriptor.ControllerType != expectedActionMethod.DeclaringType)
-                return false;
-
             MethodInfo actualActionMethod;
             var actionDescriptor = actionContext.ActionDescriptor as ReflectedHttpActionDescriptor;
             if (actionDescriptor == null)


### PR DESCRIPTION
My last pull request still had a bug with derived controllers. It went undetected because of a bug in a test helper method.

When you find a bug and fix it - do you verify that new version against your production code to be sure that particular bug has been fixed? Or do you solely rely on the unit tests you created?

If you verify against your production code, how do you do it? Do you uninstall the nuget package and manually add the assembly with the fix as reference?
