### PR TITLE
Renamed class ResourceLinkVerifier to ResourceLinkParser.

### DIFF
--- a/Hyprlinkr.UnitTest/Hyprlinkr.UnitTest.csproj
+++ b/Hyprlinkr.UnitTest/Hyprlinkr.UnitTest.csproj
@@ -125,7 +125,7 @@
     <Compile Include="ReflectionHierarchy\Base.cs" />
     <Compile Include="ReflectionHierarchy\Derived.cs" />
     <Compile Include="ReflectionHierarchy\DerivedFromDerived.cs" />
-    <Compile Include="ResourceLinkVerifierTests.cs" />
+    <Compile Include="ResourceLinkParserTests.cs" />
     <Compile Include="RoupleTests.cs" />
     <Compile Include="RouteConfiguration.cs" />
     <Compile Include="HyprlinkrCustomization.cs" />

--- a/Hyprlinkr.UnitTest/ResourceLinkParserTests.cs
+++ b/Hyprlinkr.UnitTest/ResourceLinkParserTests.cs
@@ -10,18 +10,18 @@ using Xunit.Extensions;
 
 namespace Ploeh.Hyprlinkr.UnitTest
 {
-    public class ResourceLinkVerifierTests
+    public class ResourceLinkParserTests
     {
         [Theory]
         [AutoHypData]
         public void ConstructorHasAppropriateGuards(GuardClauseAssertion assertion)
         {
-            assertion.Verify(typeof(ResourceLinkVerifier).GetConstructors());
+            assertion.Verify(typeof(ResourceLinkParser).GetConstructors());
         }
 
         [Theory]
         [AutoHypData]
-        public void ParseUriFollowsRedirect(ResourceLinkVerifier sut, string host)
+        public void ParseUriFollowsRedirect(ResourceLinkParser sut, string host)
         {
             var defaultRoute = sut.Configuration.AddDefaultRoute();
             sut.Configuration.AddPermanentRedirectRoute("Redirect", new HttpRoute("api_old/{controller}/{id}", new HttpRouteValueDictionary(new { id = RouteParameter.Optional })), defaultRoute);
@@ -35,7 +35,7 @@ namespace Ploeh.Hyprlinkr.UnitTest
 
         [Theory]
         [AutoHypData]
-        public void ParseUriReturnsCorrectValueForComplexRoute(ResourceLinkVerifier sut, string host, int id, int bar)
+        public void ParseUriReturnsCorrectValueForComplexRoute(ResourceLinkParser sut, string host, int id, int bar)
         {
             sut.Configuration.AddDefaultRoute();
             sut.Configuration.AddRoute("Complex Route", "api/{controller}/{id}/bars/{bar}", null);
@@ -50,7 +50,7 @@ namespace Ploeh.Hyprlinkr.UnitTest
         [Theory]
         [AutoHypData]
         public void ParseUriReturnsCorrectValueForUriWithOmittedOptionalParameters(
-            ResourceLinkVerifier sut, string host, int id, string bar)
+            ResourceLinkParser sut, string host, int id, string bar)
         {
             sut.Configuration.AddDefaultRoute();
             var uri = new Uri(string.Format("http://{0}/api/foo/{1}?bar={2}", host, id, bar));
@@ -64,7 +64,7 @@ namespace Ploeh.Hyprlinkr.UnitTest
         [Theory]
         [AutoHypData]
         public void ParseUriReturnsCorrectValueForUriWithOverParametrization(
-            ResourceLinkVerifier sut, string host, int id, string bar, string foo)
+            ResourceLinkParser sut, string host, int id, string bar, string foo)
         {
             sut.Configuration.AddDefaultRoute();
             var uri = new Uri(string.Format("http://{0}/api/bar/{1}?foo={2}&bar={3}", host, id, foo, bar));
@@ -78,7 +78,7 @@ namespace Ploeh.Hyprlinkr.UnitTest
         [Theory]
         [AutoHypData]
         public void ParseUriReturnsCorrectValueForUriWithQueryParameters(
-            ResourceLinkVerifier sut, string host, int id, string bar)
+            ResourceLinkParser sut, string host, int id, string bar)
         {
             sut.Configuration.AddDefaultRoute();
             var uri = new Uri(string.Format("http://{0}/api/bar/{1}?bar={2}", host, id, bar));
@@ -92,7 +92,7 @@ namespace Ploeh.Hyprlinkr.UnitTest
         [Theory]
         [AutoHypData]
         public void ParseUriReturnsCorrectValueForUriWithQueryParametersInDifferentOrder(
-            ResourceLinkVerifier sut, string host, int id, string bar, string foo)
+            ResourceLinkParser sut, string host, int id, string bar, string foo)
         {
             sut.Configuration.AddDefaultRoute();
             var uri = new Uri(string.Format("http://{0}/api/foo/{1}?foo={2}&bar={3}", host, id, foo, bar));
@@ -106,7 +106,7 @@ namespace Ploeh.Hyprlinkr.UnitTest
         [Theory]
         [AutoHypData]
         public void ParseUriReturnsCorrectValueForUriWithSuppliedOptionalParameters(
-            ResourceLinkVerifier sut, string host, int id, string bar, string foo)
+            ResourceLinkParser sut, string host, int id, string bar, string foo)
         {
             sut.Configuration.AddDefaultRoute();
             var uri = new Uri(string.Format("http://{0}/api/foo/{1}?bar={2}&foo={3}", host, id, bar, foo));
@@ -120,7 +120,7 @@ namespace Ploeh.Hyprlinkr.UnitTest
         [Theory]
         [AutoHypData]
         public void ParseUriReturnsCorrectValueForUriWithoutQueryParameters(
-            ResourceLinkVerifier sut, string host, int id)
+            ResourceLinkParser sut, string host, int id)
         {
             sut.Configuration.AddDefaultRoute();
             var uri = new Uri(string.Format("http://{0}/api/foo/{1}", host, id));
@@ -133,7 +133,7 @@ namespace Ploeh.Hyprlinkr.UnitTest
 
         [Theory]
         [AutoHypData]
-        public void ParseUriThrowsOnUriWithMultipleMatchingActions(ResourceLinkVerifier sut, string host, int id)
+        public void ParseUriThrowsOnUriWithMultipleMatchingActions(ResourceLinkParser sut, string host, int id)
         {
             sut.Configuration.AddDefaultRoute();
             var uri = new Uri(string.Format("http://{0}/api/ambiguousaction/{1}", host, id));
@@ -143,7 +143,7 @@ namespace Ploeh.Hyprlinkr.UnitTest
 
         [Theory]
         [AutoHypData]
-        public void ParseUriThrowsOnUriWithoutMatchingAction(ResourceLinkVerifier sut, string host, int id)
+        public void ParseUriThrowsOnUriWithoutMatchingAction(ResourceLinkParser sut, string host, int id)
         {
             sut.Configuration.AddDefaultRoute();
             var uri = new Uri(string.Format("http://{0}/nogetaction/{1}", host, id));
@@ -154,7 +154,7 @@ namespace Ploeh.Hyprlinkr.UnitTest
         [Theory]
         [AutoHypData]
         public void ParseUriThrowsOnUriWithoutMatchingController(
-            ResourceLinkVerifier sut, string host, int id, object controller)
+            ResourceLinkParser sut, string host, int id, object controller)
         {
             sut.Configuration.AddDefaultRoute();
             var uri = new Uri(string.Format("http://{0}/api/{1}/{2}", host, controller, id));
@@ -164,7 +164,7 @@ namespace Ploeh.Hyprlinkr.UnitTest
 
         [Theory]
         [AutoHypData]
-        public void ParseUriThrowsOnUriWithoutMatchingRoute(ResourceLinkVerifier sut, string host, int id)
+        public void ParseUriThrowsOnUriWithoutMatchingRoute(ResourceLinkParser sut, string host, int id)
         {
             sut.Configuration.AddDefaultRoute();
             var uri = new Uri(string.Format("http://{0}/foo/{1}", host, id));
@@ -174,14 +174,14 @@ namespace Ploeh.Hyprlinkr.UnitTest
 
         [Theory]
         [AutoHypData]
-        public void SutIsActionVerifier(ResourceLinkVerifier sut)
+        public void SutIsActionVerifier(ResourceLinkParser sut)
         {
             Assert.IsAssignableFrom<IActionVerifier>(sut);
         }
 
         [Theory]
         [AutoHypData]
-        public void SutIsResourceLinkParser(ResourceLinkVerifier sut)
+        public void SutIsResourceLinkParser(ResourceLinkParser sut)
         {
             Assert.IsAssignableFrom<IResourceLinkParser>(sut);
         }
@@ -189,7 +189,7 @@ namespace Ploeh.Hyprlinkr.UnitTest
         [Theory]
         [AutoHypData]
         public void TryParseUriReturnsFalseOnUriWithMultipleMatchingActions(
-            ResourceLinkVerifier sut, string host, int id)
+            ResourceLinkParser sut, string host, int id)
         {
             sut.Configuration.AddDefaultRoute();
             var uri = new Uri(string.Format("http://{0}/api/ambiguousaction/{1}", host, id));
@@ -202,7 +202,7 @@ namespace Ploeh.Hyprlinkr.UnitTest
 
         [Theory]
         [AutoHypData]
-        public void TryParseUriReturnsFalseOnUriWithoutMatchingAction(ResourceLinkVerifier sut, string host, int id)
+        public void TryParseUriReturnsFalseOnUriWithoutMatchingAction(ResourceLinkParser sut, string host, int id)
         {
             sut.Configuration.AddDefaultRoute();
             var uri = new Uri(string.Format("http://{0}/nogetaction/{1}", host, id));
@@ -216,7 +216,7 @@ namespace Ploeh.Hyprlinkr.UnitTest
         [Theory]
         [AutoHypData]
         public void TryParseUriReturnsFalseOnUriWithoutMatchingController(
-            ResourceLinkVerifier sut, string host, int id, string controller)
+            ResourceLinkParser sut, string host, int id, string controller)
         {
             sut.Configuration.AddDefaultRoute();
             var uri = new Uri(string.Format("http://{0}/api/{1}/{2}", host, controller, id));
@@ -229,7 +229,7 @@ namespace Ploeh.Hyprlinkr.UnitTest
 
         [Theory]
         [AutoHypData]
-        public void TryParseUriReturnsFalseOnUriWithoutMatchingRoute(ResourceLinkVerifier sut, string host, int id)
+        public void TryParseUriReturnsFalseOnUriWithoutMatchingRoute(ResourceLinkParser sut, string host, int id)
         {
             sut.Configuration.AddDefaultRoute();
             var uri = new Uri(string.Format("http://{0}/foo/{1}", host, id));
@@ -242,7 +242,7 @@ namespace Ploeh.Hyprlinkr.UnitTest
 
         [Theory]
         [AutoHypData]
-        public void VerifyReturnsFalseWhenActionContextIsForCorrectControllerButWrongAction(ResourceLinkVerifier sut, int id)
+        public void VerifyReturnsFalseWhenActionContextIsForCorrectControllerButWrongAction(ResourceLinkParser sut, int id)
         {
             var actionContext = GetActionContext<FooController>(x => x.GetById(id));
 
@@ -253,7 +253,7 @@ namespace Ploeh.Hyprlinkr.UnitTest
 
         [Theory]
         [AutoHypData]
-        public void VerifyReturnsFalseWhenActionContextIsForWrongController(ResourceLinkVerifier sut)
+        public void VerifyReturnsFalseWhenActionContextIsForWrongController(ResourceLinkParser sut)
         {
             var actionContext = GetActionContext<FooController>(x => x.GetDefault());
 
@@ -264,7 +264,7 @@ namespace Ploeh.Hyprlinkr.UnitTest
 
         [Theory]
         [AutoHypData]
-        public void VerifyReturnsTrueWhenActionContextIsForMethodDeclaredOnControllerBaseType(ResourceLinkVerifier sut)
+        public void VerifyReturnsTrueWhenActionContextIsForMethodDeclaredOnControllerBaseType(ResourceLinkParser sut)
         {
             var actionContext = GetActionContext<DerivedController>(x => x.BaseMethod());
 
@@ -275,7 +275,7 @@ namespace Ploeh.Hyprlinkr.UnitTest
 
         [Theory]
         [AutoHypData]
-        public void VerifyReturnsTrueWhenActionContextMatchesExpression(ResourceLinkVerifier sut, int id)
+        public void VerifyReturnsTrueWhenActionContextMatchesExpression(ResourceLinkParser sut, int id)
         {
             var actionContext = GetActionContext<FooController>(x => x.GetById(id));
 

--- a/Hyprlinkr/Hyprlinkr.csproj
+++ b/Hyprlinkr/Hyprlinkr.csproj
@@ -45,9 +45,11 @@
     <CodeAnalysisModuleSuppressionsFile>GlobalSuppressions.cs</CodeAnalysisModuleSuppressionsFile>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>..\Hyprlinkr.ruleset</CodeAnalysisRuleSet>
-    <CodeAnalysisRuleSetDirectories></CodeAnalysisRuleSetDirectories>
+    <CodeAnalysisRuleSetDirectories>
+    </CodeAnalysisRuleSetDirectories>
     <CodeAnalysisIgnoreBuiltInRuleSets>false</CodeAnalysisIgnoreBuiltInRuleSets>
-    <CodeAnalysisRuleDirectories></CodeAnalysisRuleDirectories>
+    <CodeAnalysisRuleDirectories>
+    </CodeAnalysisRuleDirectories>
     <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
@@ -85,7 +87,7 @@
     <Compile Include="IResourceLinker.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReflectionExtensions.cs" />
-    <Compile Include="ResourceLinkVerifier.cs" />
+    <Compile Include="ResourceLinkParser.cs" />
     <Compile Include="Rouple.cs" />
     <Compile Include="RouteLinker.cs" />
   </ItemGroup>

--- a/Hyprlinkr/ResourceLinkParser.cs
+++ b/Hyprlinkr/ResourceLinkParser.cs
@@ -20,26 +20,26 @@ namespace Ploeh.Hyprlinkr
     /// Example: <code>
     /// <![CDATA[
     /// HttpContextAction contextAction;
-    /// if(linkVerifier.TryParseUri(uri, out contextAction) && linkVerifier.Verify<SomeController>(x => x.SomeAction(Arg.OfType<int>)))
+    /// if(linkParser.TryParseUri(uri, out contextAction) && linkParser.Verify<SomeController>(x => x.SomeAction(Arg.OfType<int>)))
     /// {
     ///     var id = (int)contextAction.ActionArguments["id"];
     /// }
     /// ]]>
     /// </code>
     /// </remarks>
-    public class ResourceLinkVerifier : IResourceLinkParser, IActionVerifier
+    public class ResourceLinkParser : IResourceLinkParser, IActionVerifier
     {
         private readonly IHttpActionSelector actionSelector;
         private readonly HttpConfiguration configuration;
         private readonly IHttpControllerSelector controllerSelector;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ResourceLinkVerifier"/> class.
+        /// Initializes a new instance of the <see cref="ResourceLinkParser"/> class.
         /// </summary>
         /// <param name="configuration">
         /// The configuration to use to parse the URIs.
         /// </param>
-        public ResourceLinkVerifier(HttpConfiguration configuration)
+        public ResourceLinkParser(HttpConfiguration configuration)
         {
             if (configuration == null)
                 throw new ArgumentNullException("configuration");


### PR DESCRIPTION
The main purpose of this class is to extract the parameters contained in the URIs.

This is a breaking change.
