### PR TITLE
Added explicit check of RouteData with InvalidOperationException thrown ...

### DIFF
--- a/Hyprlinkr.UnitTest/RouteLinkerTests.cs
+++ b/Hyprlinkr.UnitTest/RouteLinkerTests.cs
@@ -214,6 +214,15 @@ namespace Ploeh.Hyprlinkr.UnitTest
         }
 
         [Theory, AutoHypData]
+        public void GetUriWhenRequestHasNoRouteDataThrowsArgumentException([Frozen]HttpRequestMessage request,
+            RouteLinker sut)
+        {
+            request.RequestUri = new Uri(request.RequestUri, "api/foo/");
+
+            Assert.Throws<InvalidOperationException>(() => sut.GetUri<FooController>(r => r.GetDefault()));
+        }
+
+        [Theory, AutoHypData]
         public void GetUriDoesNotMutateExistingRouteData(
             [Frozen]HttpRequestMessage request,
             RouteLinker sut)


### PR DESCRIPTION
...if no route data exists on current request. Useful for debugging in unit test scenarios.

Refactored CopyRequestWithoutRouteValues.
