### PR TITLE
Detect WebAPI2 RouteAttribute and use its route name if found

### DIFF
--- a/Hyprlinkr/DefaultRouteDispatcher.cs
+++ b/Hyprlinkr/DefaultRouteDispatcher.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Reflection;
 using System.Linq.Expressions;
+using System.Web.Http;
 
 namespace Ploeh.Hyprlinkr
 {
@@ -76,6 +77,25 @@ namespace Ploeh.Hyprlinkr
         {
             if (method == null)
                 throw new ArgumentNullException("method");
+
+            var routeAttribute = method
+                .Method
+                .GetCustomAttributes(false)
+                .Where(attribute => attribute.GetType().FullName == "System.Web.Http.RouteAttribute")
+                .FirstOrDefault();
+            
+            if (routeAttribute != null)
+            {
+                var nameProperty = routeAttribute.GetType().GetProperty("Name");
+
+                  if (nameProperty != null)
+                  {
+                      var routeName = nameProperty.GetValue(routeAttribute, null) as string;
+
+                      if (routeName != null)
+                          return new Rouple(routeName, routeValues);
+                }
+            }
 
             var newRouteValues = new Dictionary<string, object>(routeValues);
 


### PR DESCRIPTION
See issue https://github.com/ploeh/Hyprlinkr/issues/30

This isn't a complete solution - more work required to tidy up, add tests, etc. However I wanted to discuss the approach before going further.

Currently Hyprlinkr doesn't require WebAPI2 / .NET 4.5. Hence we can't use the WebAPI2 RouteAttribute directly. There's a workaround - I've tested that this pull request does the job. But it's not terribly nice having to use reflection for *everything*.

Options I can see:

1. This, suitably tidied up (and with enough protection against injection of other classes named System.Web.Http.RouteAttribute!)
2. A separate library containing an IRouteDispatcher for WebAPI2. This would then require explicit wiring up when people create their RouteLinker.
3. A separate build of Hyprlinkr for WebAPI2. I assume this isn't really an option because it'd complicate code management a lot.

Any thoughts on how comfortable you'd be with something based on this pull request? If not then I suspect option 2 would be the way to go.